### PR TITLE
Changes for Tau-embedded samples, and a bugfix

### DIFF
--- a/checkDatasetExistance.py
+++ b/checkDatasetExistance.py
@@ -5,8 +5,12 @@ from sh_tools import sh_call
 if __name__ == '__main__':
   for dataset in sys.argv[1:]:
     try:
-      _, output, _ = sh_call(['dasgoclient', '--json', '--query', f'dataset dataset={dataset}'],
-                             catch_stdout=True)
+      if dataset.endswith("USER"): # Embedded samples
+        _, output, _ = sh_call(['dasgoclient', '--json', '--query', f'dataset dataset={dataset} instance=prod/phys03'],
+                               catch_stdout=True)
+      else: 
+        _, output, _ = sh_call(['dasgoclient', '--json', '--query', f'dataset dataset={dataset}'],
+                               catch_stdout=True)
       entries = json.loads(output)
       #print(json.dumps(info, indent=2))
       ds_infos = []

--- a/crabJob.py
+++ b/crabJob.py
@@ -116,7 +116,7 @@ def processFile(jobModule, file_id, input_file, output_file, cmd_line_args, para
     else:
       local_file = f'input_{file_id}.root'
       tmp_files.append(local_file)
-      copy_remote_file(input_file, local_file, verbose=1)
+      copy_remote_file(input_file, local_file, inputDBS=params.inputDBS, verbose=1)
       module_input_file = f'file:{local_file}'
     jobModule.processFile(module_input_file, output_file, tmp_files, cmssw_report, cmd_line_args, params)
     result = True

--- a/crabJob.py
+++ b/crabJob.py
@@ -116,7 +116,7 @@ def processFile(jobModule, file_id, input_file, output_file, cmd_line_args, para
     else:
       local_file = f'input_{file_id}.root'
       tmp_files.append(local_file)
-      copy_remote_file(input_file, local_file, inputDBS=params.inputDBS, verbose=1)
+      copy_remote_file(input_file, local_file, inputDBS=params.inputDBS, custom_pfns_prefix=params.PFNSprefix, verbose=1)
       module_input_file = f'file:{local_file}'
     jobModule.processFile(module_input_file, output_file, tmp_files, cmssw_report, cmd_line_args, params)
     result = True

--- a/crabTask.py
+++ b/crabTask.py
@@ -724,7 +724,7 @@ class Task:
       taskOutput = self.getTaskOutputPath(recoveryIndex=recoveryIndex)
       jobIds = self.selectJobIds([JobStatus.finished], recoveryIndex=recoveryIndex)
       for jobId in jobIds:
-        outputFile, files = getFiles(recoveryIndex, taskOutput, jobId)
+        outputFile, files = getFiles(str(recoveryIndex), taskOutput, jobId)
         for file, file_id in files.items():
           if file not in processedFiles:
             if outputFile not in outputFiles:

--- a/nanoProdWrapper.py
+++ b/nanoProdWrapper.py
@@ -7,7 +7,7 @@ options = VarParsing('analysis')
 options.register('sampleType', '', VarParsing.multiplicity.singleton, VarParsing.varType.string,
                  "Indicates the sample type: data or mc")
 options.register('era', '', VarParsing.multiplicity.singleton, VarParsing.varType.string,
-                 "Indicates era: Run2_2016_HIPM, Run2_2016, Run2_2017, Run2_2018")
+                 "Indicates era: Run2_2016_HIPM, Run2_2016, Run2_2017, Run2_2018, Run3_2022, Run3_2022_postEE")
 options.register('skimCfg', '', VarParsing.multiplicity.singleton, VarParsing.varType.string,
                  "Skimming configuration in YAML format.")
 options.register('skimSetup', '', VarParsing.multiplicity.singleton, VarParsing.varType.string,
@@ -32,6 +32,8 @@ options.register('writePSet', False, VarParsing.multiplicity.singleton, VarParsi
                  "Dump configuration into PSet.py.")
 options.register('copyInputsToLocal', True, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
                  "Copy inputs (one at the time) to a job working directory before processing them.")
+options.register('inputDBS', 'global', VarParsing.multiplicity.singleton, VarParsing.varType.string,
+                 "DBS instance")
 options.register('output', 'nano.root', VarParsing.multiplicity.singleton, VarParsing.varType.string,
                  "Name of the output file.")
 options.register('datasetFiles', '', VarParsing.multiplicity.singleton, VarParsing.varType.string,
@@ -97,6 +99,7 @@ process.exParams = cms.untracked.PSet(
   datasetFiles = cms.untracked.string(options.datasetFiles),
   maxFiles = cms.untracked.int32(options.maxFiles),
   copyInputsToLocal = cms.untracked.bool(options.copyInputsToLocal),
+  inputDBS = cms.untracked.string(options.inputDBS),
 )
 
 if options.writePSet:

--- a/nanoProdWrapper.py
+++ b/nanoProdWrapper.py
@@ -34,6 +34,8 @@ options.register('copyInputsToLocal', True, VarParsing.multiplicity.singleton, V
                  "Copy inputs (one at the time) to a job working directory before processing them.")
 options.register('inputDBS', 'global', VarParsing.multiplicity.singleton, VarParsing.varType.string,
                  "DBS instance")
+options.register('PFNSprefix', 'global', VarParsing.multiplicity.singleton, VarParsing.varType.string,
+                 "Custom pfns prefix for input files")
 options.register('output', 'nano.root', VarParsing.multiplicity.singleton, VarParsing.varType.string,
                  "Name of the output file.")
 options.register('datasetFiles', '', VarParsing.multiplicity.singleton, VarParsing.varType.string,
@@ -100,6 +102,7 @@ process.exParams = cms.untracked.PSet(
   maxFiles = cms.untracked.int32(options.maxFiles),
   copyInputsToLocal = cms.untracked.bool(options.copyInputsToLocal),
   inputDBS = cms.untracked.string(options.inputDBS),
+  PFNSprefix = cms.untracked.string(options.PFNSprefix),
 )
 
 if options.writePSet:

--- a/sh_tools.py
+++ b/sh_tools.py
@@ -257,7 +257,7 @@ def das_file_pfns(file, disk_only=True, return_adler32=False, inputDBS='global',
   return pfns
 
 def copy_remote_file(input_remote_file, output_local_file, inputDBS='global', n_retries=4, retry_sleep_interval=10,
-                     verbose=1):
+                     custom_pfns_prefix=None, verbose=1):
   pfns_list, adler32 = das_file_pfns(input_remote_file, disk_only=False, return_adler32=True, inputDBS=inputDBS,
                                      verbose=verbose)
   if os.path.exists(output_local_file):
@@ -267,8 +267,8 @@ def copy_remote_file(input_remote_file, output_local_file, inputDBS='global', n_
 
   if len(pfns_list) == 0:
     if input_remote_file.startswith('/store/'):
-      if inputDBS=='phys03': # Probably a Tau-embedded sample stored on root://cmsxrootd-kit.gridka.de/
-        pfns_list = ["root://cmsxrootd-kit.gridka.de/"+input_remote_file, input_remote_file]
+      if custom_pfns_prefix != None:
+        pfns_list = [custom_pfns_prefix+input_remote_file, input_remote_file]
       else:
         pfns_list = [input_remote_file]
     else:


### PR DESCRIPTION
- Make `checkDatasetExistance.py` able to find Tau-embedded samples
- Propagate the DBS input from the `nanoProdWrapper.py` to `crabJob.py`
- Bugfix: Don't append xrd-redirectors to filepaths already starting with `root:`. Instead, allow "plain" paths starting with `/store` to be processed: Only these paths will have the redirectors appended to them.